### PR TITLE
feat(activity-log): add `admin.group` option

### DIFF
--- a/packages/activity-log/src/defaults.ts
+++ b/packages/activity-log/src/defaults.ts
@@ -2,6 +2,7 @@ import { type ActivityLogPluginOptions } from "./types.js";
 
 export const defaultPluginOptions: Required<ActivityLogPluginOptions> = {
   enabled: true,
+  admin: {},
   access: {},
   collections: {},
   globals: {},

--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -44,6 +44,11 @@ export const activityLogPlugin =
       ...(config.collections || []),
       {
         ...activityLog,
+        ...(mergedOptions.admin?.group && {
+          admin: {
+            group: mergedOptions.admin.group,
+          },
+        }),
         access: {
           create: () => false,
           read: (args) =>

--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -46,6 +46,7 @@ export const activityLogPlugin =
         ...activityLog,
         ...(mergedOptions.admin?.group && {
           admin: {
+            ...activityLog.admin,
             group: mergedOptions.admin.group,
           },
         }),

--- a/packages/activity-log/src/types.ts
+++ b/packages/activity-log/src/types.ts
@@ -1,4 +1,4 @@
-import { type Access, type CollectionSlug, type GlobalSlug } from "payload";
+import { type CollectionAdminOptions, type Access, type CollectionSlug, type GlobalSlug } from "payload";
 
 export type ActivityLogPluginSharedLoggingOptions = {
   enableIpAddressLogging: boolean;
@@ -12,6 +12,18 @@ export type ActivityLogPluginOptions = {
    * @default true
    */
   enabled?: boolean;
+
+  /**
+   * Admin options for the activity log collection.
+   * Only the `group` property from `CollectionAdminOptions` is used for now.
+   *
+   * @example
+   * admin: {
+   *   group: "Administration",
+   * }
+   *
+   */
+  admin?: Pick<CollectionAdminOptions, "group">;
 
   access?: {
     /**


### PR DESCRIPTION
This PR adds the ability to define `admin.group` option to the plugin's definition giving us the ability to put the "Activity Log" page inside a group.

Example :
```
activityLogPlugin({
  admin: {
    group: "Administration",
  },
  collections: {
    collections: {},
  },
  globals: {
    globals: {},
  },
}),
```
Which will result in this inside the admin :
<img width="270" height="76" alt="image" src="https://github.com/user-attachments/assets/7670d793-0b07-4d2e-8e72-3b68a768c00c" />
