### PR TITLE
feat(activity-log): add enableDraftAutosaveLogging to plugin options

### DIFF
--- a/apps/activity-log/src/payload/collections/Collections.ts
+++ b/apps/activity-log/src/payload/collections/Collections.ts
@@ -23,4 +23,11 @@ export const Collections: CollectionConfig = {
       ],
     },
   ],
+  versions: {
+    drafts: {
+      autosave: {
+          interval: 100,
+      },
+    },
+  },
 };

--- a/apps/activity-log/src/payload/globals/Globals.ts
+++ b/apps/activity-log/src/payload/globals/Globals.ts
@@ -23,4 +23,11 @@ export const Globals: GlobalConfig = {
       ],
     },
   ],
+  versions: {
+    drafts: {
+      autosave: {
+          interval: 100,
+      },
+    },
+  },
 };

--- a/packages/activity-log/src/defaults.ts
+++ b/packages/activity-log/src/defaults.ts
@@ -2,6 +2,7 @@ import { type ActivityLogPluginOptions } from "./types.js";
 
 export const defaultPluginOptions: Required<ActivityLogPluginOptions> = {
   enabled: true,
+  enableDraftAutosaveLogging: true,
   access: {},
   collections: {},
   globals: {},

--- a/packages/activity-log/src/hooks/afterChangeCollectionActivityLog.ts
+++ b/packages/activity-log/src/hooks/afterChangeCollectionActivityLog.ts
@@ -5,6 +5,7 @@ import { ACTIVITY_LOG_COLLECTION_SLUG } from "../constants.js";
 interface Options extends ActivityLogPluginSharedLoggingOptions {
   enableCreateLogging: boolean;
   enableUpdateLogging: boolean;
+  enableDraftAutosaveLogging: boolean;
 }
 
 export const afterChangeCollectionActivityLog = (
@@ -19,8 +20,8 @@ export const afterChangeCollectionActivityLog = (
       return args.doc;
     }
 
-    if (args.operation === "update" && !options.enableUpdateLogging) {
-      return args.doc;
+    if (args.operation === "update" && (!options.enableUpdateLogging || (args.req.query.draft && args.req.query.autosave && !options.enableDraftAutosaveLogging))) {
+        return args.doc;
     }
 
     try {

--- a/packages/activity-log/src/hooks/afterChangeGlobalActivityLog.ts
+++ b/packages/activity-log/src/hooks/afterChangeGlobalActivityLog.ts
@@ -2,11 +2,19 @@ import { type GlobalAfterChangeHook } from "payload";
 import { type ActivityLogPluginSharedLoggingOptions } from "../types.js";
 import { ACTIVITY_LOG_COLLECTION_SLUG } from "../constants.js";
 
+interface Options extends ActivityLogPluginSharedLoggingOptions {
+  enableDraftAutosaveLogging: boolean;
+}
+
 export const afterChangeGlobalActivityLog = (
-  options: ActivityLogPluginSharedLoggingOptions,
+  options: Options,
 ): GlobalAfterChangeHook => {
   return async (args) => {
     if (args.req.payloadAPI === "local") {
+      return args.doc;
+    }
+
+    if (args.req.query.draft && args.req.query.autosave && !options.enableDraftAutosaveLogging) {
       return args.doc;
     }
 

--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -79,16 +79,16 @@ export const activityLogPlugin =
         mergedOptions.collections[modifiedCollection.slug];
 
       const enableCreateLogging =
-        mergedCollectionOptions?.enableCreateLogging || defaultCreateLogging;
+        mergedCollectionOptions?.enableCreateLogging ?? defaultCreateLogging;
       const enableUpdateLogging =
-        mergedCollectionOptions?.enableUpdateLogging || defaultUpdateLogging;
+        mergedCollectionOptions?.enableUpdateLogging ?? defaultUpdateLogging;
       const enableDeleteLogging =
-        mergedCollectionOptions?.enableDeleteLogging || defaultDeleteLogging;
+        mergedCollectionOptions?.enableDeleteLogging ?? defaultDeleteLogging;
       const enableIpAddressLogging =
-        mergedCollectionOptions?.enableIpAddressLogging ||
+        mergedCollectionOptions?.enableIpAddressLogging ??
         defaultIpAddressLogging;
       const enableDeviceInfoLogging =
-        mergedCollectionOptions?.enableDeviceInfoLogging ||
+        mergedCollectionOptions?.enableDeviceInfoLogging ??
         defaultDeviceInfoLogging;
 
       modifiedCollection.hooks = {
@@ -128,9 +128,9 @@ export const activityLogPlugin =
         mergedOptions.collections[modifiedGlobal.slug];
 
       const enableIpAddressLogging =
-        mergedGlobalOptions?.enableIpAddressLogging || defaultIpAddressLogging;
+        mergedGlobalOptions?.enableIpAddressLogging ?? defaultIpAddressLogging;
       const enableDeviceInfoLogging =
-        mergedGlobalOptions?.enableDeviceInfoLogging ||
+        mergedGlobalOptions?.enableDeviceInfoLogging ??
         defaultDeviceInfoLogging;
 
       modifiedGlobal.hooks = {

--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -90,6 +90,8 @@ export const activityLogPlugin =
       const enableDeviceInfoLogging =
         mergedCollectionOptions?.enableDeviceInfoLogging ??
         defaultDeviceInfoLogging;
+      const enableDraftAutosaveLogging = mergedOptions.enableDraftAutosaveLogging ??
+        defaultPluginOptions?.enableDraftAutosaveLogging;
 
       modifiedCollection.hooks = {
         ...(modifiedCollection.hooks || {}),
@@ -100,6 +102,7 @@ export const activityLogPlugin =
             enableUpdateLogging,
             enableIpAddressLogging,
             enableDeviceInfoLogging,
+            enableDraftAutosaveLogging,
           }),
         ],
         afterDelete: [
@@ -132,6 +135,8 @@ export const activityLogPlugin =
       const enableDeviceInfoLogging =
         mergedGlobalOptions?.enableDeviceInfoLogging ??
         defaultDeviceInfoLogging;
+      const enableDraftAutosaveLogging = mergedOptions.enableDraftAutosaveLogging ??
+        defaultPluginOptions?.enableDraftAutosaveLogging;
 
       modifiedGlobal.hooks = {
         ...(modifiedGlobal.hooks || {}),
@@ -140,6 +145,7 @@ export const activityLogPlugin =
           afterChangeGlobalActivityLog({
             enableIpAddressLogging,
             enableDeviceInfoLogging,
+            enableDraftAutosaveLogging,
           }),
         ],
       };

--- a/packages/activity-log/src/types.ts
+++ b/packages/activity-log/src/types.ts
@@ -13,6 +13,13 @@ export type ActivityLogPluginOptions = {
    */
   enabled?: boolean;
 
+  /**
+   * Enables or disables draft autosave logging.
+   *
+   * @default true
+   */
+  enableDraftAutosaveLogging?: boolean;
+
   access?: {
     /**
      * Function that determines read access for the activity log collection.


### PR DESCRIPTION
This PR adds the ability to disable logging draft autosaves as it could quickly clog up your Activity Log table.

```
plugins: [
  activityLogPlugin({
    collections: {
      collections: {},
    },
    globals: {
      globals: {},
    },
    enableDraftAutosaveLogging: false, // defaults to true
  }),
],
```

I also replaced `||` by `??` in options handling in hooks to avoid wrong behaviour like this :
Which means `const enableIpAddressLogging = mergedGlobalOptions?.enableIpAddressLogging || defaultIpAddressLogging;` was always defaulting to `defaultIpAddressLogging` as it's true by default meaning the overrides couldn't work properly.

For reference : 
`false || true` => `true`
 `false ?? true` => `false` this is what we want