### PR TITLE
feat(activity-logs): add labels option

### DIFF
--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -41,6 +41,7 @@ export const activityLogPlugin =
             group: mergedOptions.admin.group,
           },
         }),
+        labels: mergedOptions.labels ?? undefined,
         access: {
           create: () => false,
           read: (args) => mergedOptions.access?.read?.(args) ?? Boolean(args.req.user),

--- a/packages/activity-log/src/types.ts
+++ b/packages/activity-log/src/types.ts
@@ -1,4 +1,4 @@
-import { type Access, type CollectionAdminOptions, type CollectionSlug, type GlobalSlug } from "payload";
+import { type Access, type CollectionAdminOptions, type CollectionSlug, type GlobalSlug, type Labels } from "payload";
 
 export type ActivityLogPluginSharedLoggingOptions = {
   enableIpAddressLogging: boolean;
@@ -24,6 +24,13 @@ export type ActivityLogPluginOptions = {
    *
    */
   admin?: Pick<CollectionAdminOptions, "group">;
+
+  /**
+   * Labels for the activity log collection.
+   *
+   * @default undefined
+   */
+  labels?: Labels;
 
   /**
    * Enables or disables draft autosave logging.


### PR DESCRIPTION
This PR adds the ability to add `labels` option at the plugin level in order to override / customize the default generated label which is `Activity Logs`.