### PR TITLE
fix(activity-log): allow create first user logging

### DIFF
--- a/apps/activity-log/src/payload/payload.config.ts
+++ b/apps/activity-log/src/payload/payload.config.ts
@@ -48,6 +48,7 @@ export default buildConfig({
 			collections: {
 				collections: {},
 				"collection-with-drafts": {},
+				users: {},
 			},
 			globals: {
 				globals: {},

--- a/packages/activity-log/src/hooks/afterChangeCollectionActivityLog.ts
+++ b/packages/activity-log/src/hooks/afterChangeCollectionActivityLog.ts
@@ -35,10 +35,12 @@ export const afterChangeCollectionActivityLog = (
 				collection: options.activityLogSlug,
 				data: {
 					operation: args.operation,
-					user: {
-						value: args.req.user?.id,
-						relationTo: args.req.user?.collection,
-					},
+					...(args.req.user && {
+						user: {
+							value: args.req.user.id,
+							relationTo: args.req.user.collection,
+						},
+					}),
 					ipAddress: options.enableIpAddressLogging
 						? args.req.headers.get("x-forwarded-for")
 						: undefined,

--- a/packages/activity-log/src/hooks/afterChangeGlobalActivityLog.ts
+++ b/packages/activity-log/src/hooks/afterChangeGlobalActivityLog.ts
@@ -27,10 +27,12 @@ export const afterChangeGlobalActivityLog = (
 				collection: options.activityLogSlug,
 				data: {
 					operation: "update",
-					user: {
-						value: args.req.user?.id,
-						relationTo: args.req.user?.collection,
-					},
+					...(args.req.user && {
+						user: {
+							value: args.req.user.id,
+							relationTo: args.req.user.collection,
+						},
+					}),
 					ipAddress: options.enableIpAddressLogging
 						? args.req.headers.get("x-forwarded-for")
 						: undefined,

--- a/packages/activity-log/src/hooks/afterDeleteCollectionActivityLog.ts
+++ b/packages/activity-log/src/hooks/afterDeleteCollectionActivityLog.ts
@@ -23,10 +23,12 @@ export const afterDeleteCollectionActivityLog = (
 				collection: options.activityLogSlug,
 				data: {
 					operation: "delete",
-					user: {
-						value: args.req.user?.id,
-						relationTo: args.req.user?.collection,
-					},
+					...(args.req.user && {
+						user: {
+							value: args.req.user.id,
+							relationTo: args.req.user.collection,
+						},
+					}),
 					ipAddress: options.enableIpAddressLogging
 						? args.req.headers.get("x-forwarded-for")
 						: undefined,


### PR DESCRIPTION
This PR allows logging to continue even if the `user` is unavailable on `req`.

I've added it across all of the hooks for consistency even though its technically only needed to handle the edge case of `create-first-user`.

As long as your access control is correct, `args.req.user` should never be empty with the exception of `create-first-user`.

Fixes #21 